### PR TITLE
add: Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+mixlinter

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.12 as builder
+
+WORKDIR /go/src/github.com/izumix03/mixlinter
+COPY . .
+RUN go get -u golang.org/x/tools/go/analysis
+RUN CGO_ENABLED=0 go build -i -o /mixlinter -ldflags "-s -w" ./cmd/mixlinter
+
+FROM golang:1.12-alpine
+
+RUN apk add build-base
+COPY --from=builder /mixlinter /
+
+ENTRYPOINT ["/mixlinter"]


### PR DESCRIPTION
# やったこと

- Dockerfileの追加
    - goがないと動かなかったので、`golang:1.12-alpine`を使っています。
    - alpineの場合、`build-base`ないと動かなかったです。