### PR TITLE
Allow preferred (no space style) nolint format

### DIFF
--- a/mixlinter.go
+++ b/mixlinter.go
@@ -78,7 +78,7 @@ func hasNolintComment(pass *analysis.Pass, node ast.Node) bool {
 	}
 	lineText := scanner.Text()
 
-	return strings.Contains(lineText, "// nolint:mixlinter")
+	return strings.Contains(lineText, "// nolint:mixlinter") || strings.Contains(lineText, "//nolint:mixlinter")
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {


### PR DESCRIPTION
## Description

* `//nolint:mixlinter` is supported
* `//nolint` seems more popular than `// nolint`
  * ref. https://golangci-lint.run/usage/false-positives/
    *   `Use //nolint instead of // nolint because machine-readable comments should have no space by Go convention.` 